### PR TITLE
[FEATURE] #37 부서 목록 조회 기능. 구현

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -21,7 +21,9 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
 
     // utility
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
@@ -37,12 +39,15 @@ dependencies {
 def querydslDir = "$buildDir/generated/querydsl"
 
 sourceSets {
-    main.java.srcDirs += [ querydslDir ]
+    main {
+        java {
+            srcDirs += querydslDir
+        }
+    }
 }
 
-tasks.withType(JavaCompile) {
-    options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
-//    options.compilerArgs << "-parameters"
+tasks.withType(JavaCompile).configureEach {
+    options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
 }
 
 clean.doLast {

--- a/api/src/main/java/com/reservation/api/common/presentation/dto/OrderDirectionRequest.java
+++ b/api/src/main/java/com/reservation/api/common/presentation/dto/OrderDirectionRequest.java
@@ -1,0 +1,36 @@
+package com.reservation.api.common.presentation.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.domain.Sort;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderDirectionRequest {
+    ASC(Sort.Direction.ASC),
+    DESC(Sort.Direction.DESC),
+    ;
+
+    private static final Map<String, OrderDirectionRequest> MAPPER;
+
+    static {
+        MAPPER = Arrays.stream(values())
+                .collect(Collectors.toMap(Enum::name, Function.identity()));
+    }
+
+    private final Sort.Direction direction;
+
+    public static OrderDirectionRequest findByName(String name) {
+        if (StringUtils.isBlank(name)) {
+            return DESC;
+        }
+
+        return MAPPER.getOrDefault(name.toUpperCase(), DESC);
+    }
+}

--- a/api/src/main/java/com/reservation/api/common/presentation/dto/PagingRequest.java
+++ b/api/src/main/java/com/reservation/api/common/presentation/dto/PagingRequest.java
@@ -1,0 +1,31 @@
+package com.reservation.api.common.presentation.dto;
+
+import lombok.Getter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@Getter
+public class PagingRequest {
+    private static final int DEFAULT_PAGE = 1;
+    private static final int DEFAULT_SIZE = 20;
+
+    private final Integer page;
+    private final Integer size;
+
+    public PagingRequest(Integer page, Integer size) {
+        this.page = validateValue(page, DEFAULT_PAGE);
+        this.size = validateValue(size, DEFAULT_SIZE);
+    }
+
+    private static int validateValue(Integer value, Integer defaultValue) {
+        if (value == null || value < 1) {
+            return defaultValue;
+        }
+        return value;
+    }
+
+    public Pageable pageable(Sort sort) {
+        return PageRequest.of(this.page - 1, this.size, sort);
+    }
+}

--- a/api/src/main/java/com/reservation/api/config/QueryDslConfig.java
+++ b/api/src/main/java/com/reservation/api/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package com.reservation.api.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/api/src/main/java/com/reservation/api/market/application/service/MarketAggregateService.java
+++ b/api/src/main/java/com/reservation/api/market/application/service/MarketAggregateService.java
@@ -1,7 +1,8 @@
-package com.reservation.api.user.application.service;
+package com.reservation.api.market.application.service;
 
 import com.reservation.api.market.entity.MarketEntity;
-import com.reservation.api.user.repository.MarketEntityRepository;
+import com.reservation.api.market.repository.MarketEntityRepository;
+import com.reservation.authentication.domain.principal.RequestUser;
 import com.reservation.common.error.exception.BusinessException;
 import com.reservation.common.error.type.NotFoundType;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,12 @@ import org.springframework.stereotype.Service;
 @Service
 public class MarketAggregateService {
     private final MarketEntityRepository marketEntityRepository;
+
+    public MarketEntity findUserMarketById(RequestUser requestUser) {
+        return requestUser.getAuthority().isAdmin()
+                ? findByIdOrElseThrow(requestUser.getMarketIdx())
+                : MarketEntity.console();
+    }
 
     public MarketEntity findByIdOrElseThrow(Long marketIdx) {
         return marketEntityRepository.findById(marketIdx)

--- a/api/src/main/java/com/reservation/api/market/repository/MarketEntityRepository.java
+++ b/api/src/main/java/com/reservation/api/market/repository/MarketEntityRepository.java
@@ -1,4 +1,4 @@
-package com.reservation.api.user.repository;
+package com.reservation.api.market.repository;
 
 import com.reservation.api.market.entity.MarketEntity;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/api/src/main/java/com/reservation/api/user/application/dto/UserNameMapper.java
+++ b/api/src/main/java/com/reservation/api/user/application/dto/UserNameMapper.java
@@ -1,0 +1,51 @@
+package com.reservation.api.user.application.dto;
+
+import com.reservation.api.user.entity.UserEntity;
+import com.reservation.common.application.executor.CryptoExecutor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class UserNameMapper {
+    private static final String SYSTEM_NAME = "SYSTEM";
+    private static final String WITHDRAWAL_USERNAME = "탈퇴한 유저입니다.";
+
+    private final Map<Long, String> MAPPER = new HashMap<>();
+
+    public static UserNameMapper from(List<UserEntity> users) {
+        if (CollectionUtils.isEmpty(users)) {
+            return new UserNameMapper(Collections.emptyMap());
+        }
+        return new UserNameMapper(
+                users.stream()
+                        .collect(Collectors.toMap(UserEntity::getIdx, UserEntity::getName))
+        );
+    }
+
+    private UserNameMapper(Map<Long, String> mapper) {
+        if (!CollectionUtils.isEmpty(mapper)) {
+            this.MAPPER.putAll(mapper);
+        }
+    }
+
+    public String getDecryptNameOrBlank(Long idx) {
+        if (idx == null) {
+            return null;
+        }
+
+        if (idx == 0L) {
+            return SYSTEM_NAME;
+        }
+
+        String name = MAPPER.getOrDefault(idx, null);
+
+        return StringUtils.isBlank(name)
+                ? WITHDRAWAL_USERNAME
+                : CryptoExecutor.decrypt(name);
+    }
+}

--- a/api/src/main/java/com/reservation/api/user/application/service/DepartmentAggregateService.java
+++ b/api/src/main/java/com/reservation/api/user/application/service/DepartmentAggregateService.java
@@ -1,25 +1,37 @@
 package com.reservation.api.user.application.service;
 
+import com.reservation.api.market.application.service.MarketAggregateService;
 import com.reservation.api.market.entity.MarketEntity;
+import com.reservation.api.user.application.dto.UserNameMapper;
 import com.reservation.api.user.entity.DepartmentEntity;
 import com.reservation.api.user.presentation.dto.request.DepartmentCommandRequest;
+import com.reservation.api.user.presentation.dto.request.DepartmentsQueryRequest;
+import com.reservation.api.user.presentation.dto.response.DepartmentsResponse;
 import com.reservation.api.user.repository.DepartmentEntityRepository;
+import com.reservation.api.user.repository.custom.DepartmentCustomRepository;
+import com.reservation.api.user.repository.dto.query.DepartmentsQueryDto;
 import com.reservation.authentication.domain.principal.RequestUser;
 import com.reservation.common.error.exception.BusinessException;
 import com.reservation.common.error.type.ConflictType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @RequiredArgsConstructor
 @Service
 public class DepartmentAggregateService {
+    private final UserAggregateService userAggregateService;
     private final MarketAggregateService marketAggregateService;
     private final DepartmentEntityRepository departmentEntityRepository;
+    private final DepartmentCustomRepository departmentCustomRepository;
 
     public void registerDepartment(RequestUser requestUser, DepartmentCommandRequest commandRequest) {
-        MarketEntity market = (requestUser.getAuthority().isAdmin())
-                ? marketAggregateService.findByIdOrElseThrow(requestUser.getMarketIdx())
-                : MarketEntity.console();
+        MarketEntity market = marketAggregateService.findUserMarketById(requestUser);
 
         DepartmentEntity department = DepartmentEntity.insertEntity(market, commandRequest.getName(), commandRequest.getRequestDatetime(), requestUser.getIdxAsLong());
 
@@ -27,5 +39,22 @@ public class DepartmentAggregateService {
             throw new BusinessException(ConflictType.DEPARTMENT_NAME_EXISTS);
         }
         departmentEntityRepository.save(department);
+    }
+
+    public DepartmentsResponse fetchDepartments(RequestUser requestUser, DepartmentsQueryRequest queryRequest) {
+        MarketEntity market = marketAggregateService.findUserMarketById(requestUser);
+
+        DepartmentsQueryDto queryDto = queryRequest.toQueryDto(market.getIdx());
+
+        Page<DepartmentEntity> departments = departmentCustomRepository.pagingSearchByQueryDto(queryDto);
+
+        Set<Long> userIdxes = departments.stream()
+                .flatMap(department -> Stream.of(department.getRegIdx(), department.getModIdx()))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        UserNameMapper userNameMapper = userAggregateService.generateUserNameMapper(userIdxes);
+
+        return DepartmentsResponse.from(departments, userNameMapper);
     }
 }

--- a/api/src/main/java/com/reservation/api/user/application/service/UserAggregateService.java
+++ b/api/src/main/java/com/reservation/api/user/application/service/UserAggregateService.java
@@ -1,5 +1,6 @@
 package com.reservation.api.user.application.service;
 
+import com.reservation.api.user.application.dto.UserNameMapper;
 import com.reservation.api.user.entity.AdminIdentifyEntity;
 import com.reservation.api.user.entity.ConsoleIdentifyEntity;
 import com.reservation.api.user.entity.UserEntity;
@@ -12,10 +13,15 @@ import com.reservation.api.user.repository.UserIdentifyEntityRepository;
 import com.reservation.authentication.domain.principal.RequestUser;
 import com.reservation.common.error.exception.BusinessException;
 import com.reservation.common.error.type.BadRequestType;
+import com.reservation.common.error.type.InternalServerErrorType;
 import com.reservation.common.error.type.NotFoundType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+
+import java.util.List;
+import java.util.Set;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -53,5 +59,15 @@ public class UserAggregateService {
                 .orElseThrow(() -> new BusinessException(NotFoundType.NOT_FOUND_USER_DATA));
 
         userEntityRepository.delete(userEntity);
+    }
+
+    public UserNameMapper generateUserNameMapper(Set<Long> userIdxes) {
+        if (CollectionUtils.isEmpty(userIdxes)) {
+            throw new BusinessException(InternalServerErrorType.USER_IDX_MUST_NOT_BE_EMPTY);
+        }
+
+        List<UserEntity> userEntities = userEntityRepository.findAllById(userIdxes);
+
+        return UserNameMapper.from(userEntities);
     }
 }

--- a/api/src/main/java/com/reservation/api/user/entity/AdminIdentifyEntity.java
+++ b/api/src/main/java/com/reservation/api/user/entity/AdminIdentifyEntity.java
@@ -37,18 +37,15 @@ public class AdminIdentifyEntity extends BaseDatetimeEntity {
     @Column(length = 50)
     private String identificationNumber;
 
-    @Column(nullable = false, length = 50)
-    private String name;
-
     public static AdminIdentifyEntity create(RoleEntity role, String id, String password, MarketEntity market, DepartmentEntity department, String position, String identificationNumber, String name, String email, LocalDateTime regDatetime) {
         return new AdminIdentifyEntity(role, id, password, market, department, position, identificationNumber, name, email, regDatetime);
     }
 
     private AdminIdentifyEntity(RoleEntity role, String id, String password, MarketEntity market, DepartmentEntity department, String position, String identificationNumber, String name, String email, LocalDateTime regDatetime) {
-        this(null, UserEntity.create(role, id, password, email, regDatetime), market, department, position, identificationNumber, name, regDatetime);
+        this(null, UserEntity.create(role, id, password, name, email, regDatetime), market, department, position, identificationNumber, regDatetime);
     }
 
-    private AdminIdentifyEntity(Long userIdx, UserEntity user, MarketEntity market, DepartmentEntity department, String position, String identificationNumber, String name, LocalDateTime regDatetime) {
+    private AdminIdentifyEntity(Long userIdx, UserEntity user, MarketEntity market, DepartmentEntity department, String position, String identificationNumber, LocalDateTime regDatetime) {
         super(regDatetime);
         this.userIdx = userIdx;
         this.user = user;
@@ -56,6 +53,5 @@ public class AdminIdentifyEntity extends BaseDatetimeEntity {
         this.department = department;
         this.position = position;
         this.identificationNumber = identificationNumber;
-        this.name = name;
     }
 }

--- a/api/src/main/java/com/reservation/api/user/entity/ConsoleIdentifyEntity.java
+++ b/api/src/main/java/com/reservation/api/user/entity/ConsoleIdentifyEntity.java
@@ -29,19 +29,15 @@ public class ConsoleIdentifyEntity extends BaseDatetimeEntity {
     @Column(nullable = false, length = 20)
     private String position;
 
-    @Column(nullable = false, length = 50)
-    private String name;
-
     private ConsoleIdentifyEntity(RoleEntity role, String id, String password, DepartmentEntity department, String position, String name, String email, LocalDateTime regDatetime) {
-        this(null, UserEntity.create(role, id, password, email, regDatetime), department, position, name, regDatetime);
+        this(null, UserEntity.create(role, id, password, name, email, regDatetime), department, position, regDatetime);
     }
 
-    private ConsoleIdentifyEntity(Long userIdx, UserEntity user, DepartmentEntity department, String position, String name, LocalDateTime regDatetime) {
+    private ConsoleIdentifyEntity(Long userIdx, UserEntity user, DepartmentEntity department, String position, LocalDateTime regDatetime) {
         super(regDatetime);
         this.userIdx = userIdx;
         this.user = user;
         this.department = department;
         this.position = position;
-        this.name = name;
     }
 }

--- a/api/src/main/java/com/reservation/api/user/entity/UserEntity.java
+++ b/api/src/main/java/com/reservation/api/user/entity/UserEntity.java
@@ -29,26 +29,30 @@ public class UserEntity extends BaseDatetimeEntity {
     @Column(nullable = false, length = 100)
     private String password;
 
+    @Column(nullable = false, length = 50)
+    private String name;
+
     @Column(unique = true, nullable = false, length = 50)
     private String email;
 
     @Column(nullable = false)
     private Boolean isActive;
 
-    public static UserEntity create(RoleEntity role, String id, String password, String email, LocalDateTime regDatetime) {
-        return new UserEntity(role, id, password, email, true, regDatetime);
+    public static UserEntity create(RoleEntity role, String id, String password, String name, String email, LocalDateTime regDatetime) {
+        return new UserEntity(role, id, password, name, email, true, regDatetime);
     }
 
-    private UserEntity(RoleEntity role, String id, String password, String email, Boolean isActive, LocalDateTime regDatetime) {
-        this(null, role, id, password, email, isActive, regDatetime);
+    private UserEntity(RoleEntity role, String id, String password, String name, String email, Boolean isActive, LocalDateTime regDatetime) {
+        this(null, role, id, password, name, email, isActive, regDatetime);
     }
 
-    private UserEntity(Long idx, RoleEntity role, String id, String password, String email, Boolean isActive, LocalDateTime regDatetime) {
+    private UserEntity(Long idx, RoleEntity role, String id, String password, String name, String email, Boolean isActive, LocalDateTime regDatetime) {
         super(regDatetime);
         this.idx = idx;
         this.role = role;
         this.id = id;
         this.password = password;
+        this.name = name;
         this.email = email;
         this.isActive = isActive;
     }

--- a/api/src/main/java/com/reservation/api/user/entity/UserIdentifyEntity.java
+++ b/api/src/main/java/com/reservation/api/user/entity/UserIdentifyEntity.java
@@ -27,9 +27,6 @@ public class UserIdentifyEntity extends BaseDatetimeEntity {
     private UserEntity user;
 
     @Column(nullable = false, length = 50)
-    private String name;
-
-    @Column(nullable = false, length = 50)
     private String phone;
 
     @Column(nullable = false, length = 50)
@@ -57,14 +54,13 @@ public class UserIdentifyEntity extends BaseDatetimeEntity {
     }
 
     private UserIdentifyEntity(RoleEntity role, String id, String password, String name, String phone, String email, String nickname, GenderType gender, String birth, String ci, String di, RegisterType registerType, LocalDateTime regDatetime) {
-        this(null, UserEntity.create(role, id, password, email, regDatetime), name, phone, nickname, gender, birth, ci, di, registerType, regDatetime);
+        this(null, UserEntity.create(role, id, password, name, email, regDatetime), phone, nickname, gender, birth, ci, di, registerType, regDatetime);
     }
 
-    private UserIdentifyEntity(Long userIdx, UserEntity user, String name, String phone, String nickname, GenderType gender, String birth, String ci, String di, RegisterType registerType, LocalDateTime regDatetime) {
+    private UserIdentifyEntity(Long userIdx, UserEntity user, String phone, String nickname, GenderType gender, String birth, String ci, String di, RegisterType registerType, LocalDateTime regDatetime) {
         super(regDatetime);
         this.userIdx = userIdx;
         this.user = user;
-        this.name = name;
         this.phone = phone;
         this.nickname = nickname;
         this.gender = gender;

--- a/api/src/main/java/com/reservation/api/user/presentation/DepartmentController.java
+++ b/api/src/main/java/com/reservation/api/user/presentation/DepartmentController.java
@@ -2,6 +2,8 @@ package com.reservation.api.user.presentation;
 
 import com.reservation.api.user.application.service.DepartmentAggregateService;
 import com.reservation.api.user.presentation.dto.request.DepartmentCommandRequest;
+import com.reservation.api.user.presentation.dto.request.DepartmentsQueryRequest;
+import com.reservation.api.user.presentation.dto.response.DepartmentsResponse;
 import com.reservation.authentication.domain.annotation.Authenticated;
 import com.reservation.authentication.domain.annotation.RequireRole;
 import com.reservation.authentication.domain.principal.RequestUser;
@@ -13,29 +15,40 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "부서 관련 기본 CRUD", description = "관리자, 백오피스 유저의 부서와 관련된 기본 CRUD 기능 제공")
 @RequiredArgsConstructor
+@RequireRole({Authority.ADMIN, Authority.CONSOLE})
 @RequestMapping("/departments")
 @RestController
 public class DepartmentController {
     private final DepartmentAggregateService departmentAggregateService;
 
-    @Operation(summary = "부서 등록", description = "관리자가 소속한 상점의 부서 등록")
+    @Operation(summary = "부서 등록", description = "관리자, 백오피스 유저가 소속한 상점의 부서 등록")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "성공")
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "404", description = "상점 정보 없음"),
+            @ApiResponse(responseCode = "409", description = "동일한 부서 명칭 존재")
     })
     @PostMapping
-    @RequireRole({Authority.ADMIN, Authority.CONSOLE})
     public ResponseEntity<Void> registerMarketDepartment(@Authenticated RequestUser requestUser,
                                                          @RequestBody @Valid DepartmentCommandRequest commandRequest) {
 
         departmentAggregateService.registerDepartment(requestUser, commandRequest);
 
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "부서 목록 조회", description = "관리자, 백오피스 유저가 소속한 상점의 페이징 목록 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공(목록이 없을 경우 포함)"),
+            @ApiResponse(responseCode = "404", description = "상점 정보 없음")
+    })
+    @GetMapping
+    public ResponseEntity<DepartmentsResponse> fetchDepartments(@Authenticated RequestUser requestUser,
+                                                                @ModelAttribute @Valid DepartmentsQueryRequest queryRequest) {
+
+        return ResponseEntity.ok(departmentAggregateService.fetchDepartments(requestUser, queryRequest));
     }
 }

--- a/api/src/main/java/com/reservation/api/user/presentation/dto/request/DepartmentsQueryRequest.java
+++ b/api/src/main/java/com/reservation/api/user/presentation/dto/request/DepartmentsQueryRequest.java
@@ -1,0 +1,62 @@
+package com.reservation.api.user.presentation.dto.request;
+
+import com.reservation.api.common.presentation.dto.OrderDirectionRequest;
+import com.reservation.api.common.presentation.dto.PagingRequest;
+import com.reservation.api.user.repository.dto.query.DepartmentsQueryDto;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Getter
+public class DepartmentsQueryRequest extends PagingRequest {
+    private final String name;
+    private final DepartmentOrderFields orderFields;
+    private final OrderDirectionRequest orderDirection;
+
+    public DepartmentsQueryRequest(Integer page, Integer size, String name, String orderFields, String orderDirection) {
+        super(page, size);
+        this.name = name;
+        this.orderFields = DepartmentOrderFields.findByName(orderFields);
+        this.orderDirection = OrderDirectionRequest.findByName(orderDirection);
+    }
+
+    public DepartmentsQueryDto toQueryDto(Long marketIdx) {
+        return new DepartmentsQueryDto(
+                marketIdx,
+                this.name,
+                super.pageable(Sort.by(this.orderDirection.getDirection(), this.orderFields.field))
+        );
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    enum DepartmentOrderFields {
+        NAME("name"),
+        REGISTRATION_DATETIME("reg_datetime"),
+        MODIFICATION_DATETIME("mod_datetime"),
+        ;
+
+        private static final Map<String, DepartmentOrderFields> MAPPER;
+
+        static {
+            MAPPER = Arrays.stream(values())
+                    .collect(Collectors.toMap(Enum::name, Function.identity()));
+        }
+
+        private final String field;
+
+        private static DepartmentOrderFields findByName(String name) {
+            if (!StringUtils.hasText(name)) {
+                return REGISTRATION_DATETIME;
+            }
+
+            return MAPPER.getOrDefault(name.toUpperCase(), REGISTRATION_DATETIME);
+        }
+    }
+}

--- a/api/src/main/java/com/reservation/api/user/presentation/dto/response/AdminAdditionalDetailResponse.java
+++ b/api/src/main/java/com/reservation/api/user/presentation/dto/response/AdminAdditionalDetailResponse.java
@@ -1,21 +1,18 @@
 package com.reservation.api.user.presentation.dto.response;
 
 import com.reservation.api.user.entity.AdminIdentifyEntity;
-import com.reservation.common.application.executor.CryptoExecutor;
 
 public record AdminAdditionalDetailResponse (
         UserDepartmentResponse department,
         String position,
-        String identificationNumber,
-        String name
+        String identificationNumber
 ) implements AdditionalDetailResponse {
 
     public static AdminAdditionalDetailResponse from(AdminIdentifyEntity entity) {
         return new AdminAdditionalDetailResponse(
                 UserDepartmentResponse.from(entity.getDepartment()),
                 entity.getPosition(),
-                entity.getIdentificationNumber(),
-                CryptoExecutor.decrypt(entity.getName())
+                entity.getIdentificationNumber()
         );
     }
 }

--- a/api/src/main/java/com/reservation/api/user/presentation/dto/response/BasicDetailResponse.java
+++ b/api/src/main/java/com/reservation/api/user/presentation/dto/response/BasicDetailResponse.java
@@ -2,11 +2,13 @@ package com.reservation.api.user.presentation.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.reservation.api.user.entity.UserEntity;
+import com.reservation.common.application.executor.CryptoExecutor;
 
 import java.time.LocalDateTime;
 
 public record BasicDetailResponse(
         String id,
+        String name,
         String email,
         @JsonFormat(pattern = "yyyy.MM.dd HH:mm:ss")
         LocalDateTime regDatetime
@@ -14,6 +16,7 @@ public record BasicDetailResponse(
     public static BasicDetailResponse from(UserEntity user) {
         return new BasicDetailResponse(
                 user.getId(),
+                CryptoExecutor.decrypt(user.getName()),
                 user.getEmail(),
                 user.getRegDatetime()
         );

--- a/api/src/main/java/com/reservation/api/user/presentation/dto/response/ConsoleAdditionalDetailResponse.java
+++ b/api/src/main/java/com/reservation/api/user/presentation/dto/response/ConsoleAdditionalDetailResponse.java
@@ -1,18 +1,15 @@
 package com.reservation.api.user.presentation.dto.response;
 
 import com.reservation.api.user.entity.ConsoleIdentifyEntity;
-import com.reservation.common.application.executor.CryptoExecutor;
 
 public record ConsoleAdditionalDetailResponse (
         UserDepartmentResponse department,
-        String position,
-        String name
+        String position
 ) implements AdditionalDetailResponse {
     public static ConsoleAdditionalDetailResponse from(ConsoleIdentifyEntity entity) {
         return new ConsoleAdditionalDetailResponse(
                 UserDepartmentResponse.from(entity.getDepartment()),
-                entity.getPosition(),
-                CryptoExecutor.decrypt(entity.getName())
+                entity.getPosition()
         );
     }
 }

--- a/api/src/main/java/com/reservation/api/user/presentation/dto/response/DepartmentResponse.java
+++ b/api/src/main/java/com/reservation/api/user/presentation/dto/response/DepartmentResponse.java
@@ -1,0 +1,28 @@
+package com.reservation.api.user.presentation.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.reservation.api.user.entity.DepartmentEntity;
+
+import java.time.LocalDateTime;
+
+public record DepartmentResponse(
+        Long idx,
+        String name,
+        @JsonFormat(pattern = "yyyy.MM.dd HH:mm:ss")
+        LocalDateTime regDatetime,
+        String regUserId,
+        @JsonFormat(pattern = "yyyy.MM.dd HH:mm:ss")
+        LocalDateTime lastModifyDatetime,
+        String lastModifyUserId
+) {
+    public static DepartmentResponse of(DepartmentEntity department, String regUserId, String lastModifyUserId) {
+        return new DepartmentResponse(
+                department.getIdx(),
+                department.getName(),
+                department.getRegDatetime(),
+                regUserId,
+                department.getModDatetime(),
+                lastModifyUserId
+        );
+    }
+}

--- a/api/src/main/java/com/reservation/api/user/presentation/dto/response/DepartmentsResponse.java
+++ b/api/src/main/java/com/reservation/api/user/presentation/dto/response/DepartmentsResponse.java
@@ -1,0 +1,29 @@
+package com.reservation.api.user.presentation.dto.response;
+
+import com.reservation.api.user.application.dto.UserNameMapper;
+import com.reservation.api.user.entity.DepartmentEntity;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+import org.springframework.util.CollectionUtils;
+
+@Getter
+public class DepartmentsResponse {
+    private final Page<DepartmentResponse> departments;
+
+    public static DepartmentsResponse from(Page<DepartmentEntity> entities, UserNameMapper nameMapper) {
+        if (CollectionUtils.isEmpty(entities.getContent())) {
+            return new DepartmentsResponse(Page.empty());
+        }
+
+        Page<DepartmentResponse> response = entities.map(entity -> DepartmentResponse.of(
+                entity,
+                nameMapper.getDecryptNameOrBlank(entity.getRegIdx()),
+                nameMapper.getDecryptNameOrBlank(entity.getModIdx())));
+
+        return new DepartmentsResponse(response);
+    }
+
+    private DepartmentsResponse(Page<DepartmentResponse> departments) {
+        this.departments = departments;
+    }
+}

--- a/api/src/main/java/com/reservation/api/user/presentation/dto/response/UserAdditionalDetailResponse.java
+++ b/api/src/main/java/com/reservation/api/user/presentation/dto/response/UserAdditionalDetailResponse.java
@@ -4,14 +4,12 @@ import com.reservation.api.user.entity.UserIdentifyEntity;
 import com.reservation.common.application.executor.CryptoExecutor;
 
 public record UserAdditionalDetailResponse (
-        String name,
         String phone,
         String nickname,
         String birth
 ) implements AdditionalDetailResponse {
     public static UserAdditionalDetailResponse from(UserIdentifyEntity userIdentify) {
         return new UserAdditionalDetailResponse(
-                CryptoExecutor.decrypt(userIdentify.getName()),
                 CryptoExecutor.decrypt(userIdentify.getPhone()),
                 userIdentify.getNickname(),
                 userIdentify.getBirth()

--- a/api/src/main/java/com/reservation/api/user/repository/custom/DepartmentCustomRepository.java
+++ b/api/src/main/java/com/reservation/api/user/repository/custom/DepartmentCustomRepository.java
@@ -1,0 +1,14 @@
+package com.reservation.api.user.repository.custom;
+
+import com.reservation.api.user.entity.DepartmentEntity;
+import com.reservation.api.user.repository.dto.query.DepartmentsQueryDto;
+import org.springframework.data.domain.Page;
+
+public interface DepartmentCustomRepository {
+    /**
+     * 검색 조건을 통한 부서의 페이징 목록 반환
+     * @param queryDto 검색 조건 dto
+     * @return 검색 결과 부서 목록
+     */
+    Page<DepartmentEntity> pagingSearchByQueryDto(DepartmentsQueryDto queryDto);
+}

--- a/api/src/main/java/com/reservation/api/user/repository/custom/impl/DepartmentCustomRepositoryImpl.java
+++ b/api/src/main/java/com/reservation/api/user/repository/custom/impl/DepartmentCustomRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.reservation.api.user.repository.    custom.impl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.reservation.api.user.entity.DepartmentEntity;
+import com.reservation.api.user.repository.custom.DepartmentCustomRepository;
+import com.reservation.api.user.repository.dto.query.DepartmentsQueryDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.reservation.api.user.entity.QDepartmentEntity.departmentEntity;
+
+@RequiredArgsConstructor
+@Repository
+public class DepartmentCustomRepositoryImpl implements DepartmentCustomRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<DepartmentEntity> pagingSearchByQueryDto(DepartmentsQueryDto queryDto) {
+        List<DepartmentEntity> departments = queryFactory.selectFrom(departmentEntity)
+                .where(queryDto.searchName(), queryDto.eqMarketIdx())
+                .fetch();
+
+        return PageableExecutionUtils.getPage(departments, queryDto, departments::size);
+    }
+}

--- a/api/src/main/java/com/reservation/api/user/repository/dto/query/DepartmentsQueryDto.java
+++ b/api/src/main/java/com/reservation/api/user/repository/dto/query/DepartmentsQueryDto.java
@@ -1,0 +1,34 @@
+package com.reservation.api.user.repository.dto.query;
+
+import com.querydsl.core.BooleanBuilder;
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import static com.reservation.api.user.entity.QDepartmentEntity.departmentEntity;
+
+@Getter
+public class DepartmentsQueryDto extends PageRequest {
+    private final Long marketIdx;
+    private final String name;
+
+    public DepartmentsQueryDto(Long marketIdx, String name, Pageable pageable) {
+        super(pageable.getPageNumber(), pageable.getPageSize(), pageable.getSort());
+        this.marketIdx = marketIdx;
+        this.name = name;
+    }
+
+    public BooleanBuilder searchName() {
+        if (StringUtils.isBlank(this.name)) {
+            return new BooleanBuilder();
+        }
+        return new BooleanBuilder()
+                .and(departmentEntity.name.contains(this.name));
+    }
+
+    public BooleanBuilder eqMarketIdx() {
+        return new BooleanBuilder()
+                .and(departmentEntity.market.idx.eq(this.marketIdx));
+    }
+}

--- a/api/src/main/resources/db/migration/V6__modify_user_name_field_location.sql
+++ b/api/src/main/resources/db/migration/V6__modify_user_name_field_location.sql
@@ -1,0 +1,9 @@
+-- 모든 유형의 유저 이름 필드 변경
+-- 각각의 entity -> 통합 entity로 이동 unique 처리
+
+ALTER TABLE user.user_identify DROP COLUMN name;
+ALTER TABLE user.admin_identify DROP COLUMN name;
+ALTER TABLE user.console_identify DROP COLUMN name;
+
+ALTER TABLE user.user ADD COLUMN name varchar(50) NOT NULL COMMENT '이름(양방향 암호화)' AFTER password;
+CREATE INDEX user_name_index ON user.user(name);

--- a/common/src/main/java/com/reservation/common/error/type/InternalServerErrorType.java
+++ b/common/src/main/java/com/reservation/common/error/type/InternalServerErrorType.java
@@ -13,6 +13,7 @@ public enum InternalServerErrorType implements ErrorType {
     INVALID_REDIS_KEY_PARAMETERS(3, "Redis 키 생성을 위한 파라미터가 올바르지 않습니다."),
     FAILED_TO_ENCRYPT_VALUE(4, "개인정보 암호화에 실패했습니다."),
     FAILED_TO_DECRYPT_VALUE(5, "개인정보 복호화에 실패했습니다."),
+    USER_IDX_MUST_NOT_BE_EMPTY(6, "유저 정보를 조회하기 위해서는 인덱스 목록이 반드시 필요합니다."),
     ;
 
     private final HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
### 1. 배경
> 부서 목록 조회 기능 구현 및 QueryDSL 사용을 위한 QClass 생성 과정에서 의존성 부족으로 인한 생성오류 수정
> 각 유저의 이름 필드를 유저 상세 테이블에서 기본 테이블로 위치 이동

### 2. 작업내용
1. Qclass를 위한 의존성 추가
2. 유저 이름 필드 위치 변경
3. 부서 조회 기능 구현
  3-1. Response 규격에 대해서는 고민중